### PR TITLE
Tests for dash in branch name. Fixes #2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,3 +2,4 @@ build: off
 
 test_script:
     - test\hg\bat\test-incoming.bat
+    - test\hg\bat\test-incoming.bat branch-with-dash

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ install: true
 script:
     - chmod +x test/hg/bash/test-incoming.sh
     - ./test/hg/bash/test-incoming.sh
+    - ./test/hg/bash/test-incoming.sh with-dash

--- a/src/hg/bat/incoming.bat
+++ b/src/hg/bat/incoming.bat
@@ -8,18 +8,18 @@ set closed=hg log -r "closed() and branch(%BRANCH%)" --template "{node}\n"
 FOR /F "tokens=*" %%f in ('%first%') do SET INITIAL=%%f
 rem On new branch
 if "%HG_NODE%"=="%INITIAL%" (
-if not "%~1"=="" call %~1 %BRANCH% %HG_NODE%
+if not "%~1"=="" call %~1 "%BRANCH%" "%HG_NODE%"
 goto done
 )
 FOR /F "tokens=*" %%f in ('%closed%') do SET CLOSE=%%f
 
 rem On close branch
 if "%HG_NODE%"=="%CLOSE%" (
-if not "%~3"=="" call %~3 %BRANCH% %HG_NODE%
+if not "%~3"=="" call %~3 "%BRANCH%" "%HG_NODE%"
 goto done
 )
 
 rem On existing branch
-if not "%~2"=="" call %~2 %BRANCH% %HG_NODE%
+if not "%~2"=="" call %~2 "%BRANCH%" "%HG_NODE%"
 goto done
 :done

--- a/test/hg/bash/change-branch.sh
+++ b/test/hg/bash/change-branch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z $2 ]; then
+   echo "ERROR: Branch name not given. Cannot create branch without name."
+   exit 1
+fi
+
+CURRENT=$(hg branch)
+
+if [ "$CURRENT" = "$1" ]; then 
+    echo "WARN: Already in given branch."
+fi
+
+hg -R $1 branch $2
+hg -R $1 push -f

--- a/test/hg/bash/test-incoming.sh
+++ b/test/hg/bash/test-incoming.sh
@@ -8,6 +8,12 @@ checkReturnCode() {
     fi
 }
 
+BRANCH=$1
+
+if [ -z $BRANCH ]; then 
+    BRANCH=default
+fi
+
 REPO1=repository1
 REPO2=repository2
 SCRIPT_PATH=$(dirname `which $0`)
@@ -31,6 +37,7 @@ source $SCRIPT_PATH/add-hook.sh $REPO1 incoming "$NP"  "$NE" "$NC"
 ret_code=$? 
 checkReturnCode $ret_code $CLEANUP
 
+source $SCRIPT_PATH/change-branch.sh $ABSOLUTE/$REPO2 $BRANCH
 
 source $SCRIPT_PATH/change-file.sh $ABSOLUTE/$REPO2 "file"
 ret_code=$? 
@@ -44,9 +51,9 @@ source $SCRIPT_PATH/close-branch.sh $ABSOLUTE/$REPO2
 ret_code=$? 
 checkReturnCode $ret_code $CLEANUP
 
-EXPECTED_NEW=("default")
-EXPECTED_EXISTING=("default")
-EXPECTED_CLOSED=("default")
+EXPECTED_NEW=("$BRANCH")
+EXPECTED_EXISTING=("$BRANCH")
+EXPECTED_CLOSED=("$BRANCH")
 I=0
 while IFS='' read -r line || [[ -n "$line" ]]; do
     linearr=($line)
@@ -55,7 +62,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
     fi
     let "I++"
 done < "$NEWBRANCH"
-if [! $i -eq ${EXPECTED_NEW[@]} ]; then
+if [ "$I" -ne "${#EXPECTED_NEW[@]}" ]; then
     RESULT=1
 fi
 I=0
@@ -68,7 +75,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
     let "I++"
 done < "$EXISTING"
 
-if [! $i -eq ${EXPECTED_EXISTING[@]} ]; then
+if [ "$I" -ne "${#EXPECTED_EXISTING[@]}" ]; then
     RESULT=1
 fi
 
@@ -82,7 +89,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
     let "I++"
 done < "$CLOSED"
 
-if [! $i -eq ${EXPECTED_CLOSED[@]} ]; then
+if [ "$I" -ne "${#EXPECTED_CLOSED[@]}" ]; then
     RESULT=1
 fi
 

--- a/test/hg/bat/change-branch.bat
+++ b/test/hg/bat/change-branch.bat
@@ -1,0 +1,18 @@
+IF [%2] == [] GOTO BranchNotSet
+
+
+for /f %%i in ('hg -R %1 branch') do set current=%%i
+
+if [%2] == [%current%] GOTO Ready
+
+hg -R %1 branch %2
+hg -R %1 push -f
+GOTO Ready
+
+
+:BranchNotSet
+echo "ERROR: Cannot change branch if it is not defined"
+exit 1
+
+:Ready
+

--- a/test/hg/bat/test-incoming.bat
+++ b/test/hg/bat/test-incoming.bat
@@ -1,6 +1,7 @@
 @ECHO OFF
 setlocal EnableDelayedExpansion
-
+set branch=%1
+if [%branch%] == [] set branch=default
 set result=0
 set r1=repository1
 set r2=repository2
@@ -17,16 +18,16 @@ if errorlevel 1 (
     set result=1
     goto CLEANUP
 )
-
+call %~dp0\change-branch.bat %r2% %branch%
 call %~dp0\change-file.bat %r2% file
 call %~dp0\change-file.bat %r2% file
 call %~dp0\close-branch.bat %r2%
 
 rem Verify results
 echo Starting to verify results
-set expectedNew[0]=default
-set expectedExisting[0]=default
-set expectedClose[0]=default
+set expectedNew[0]=%branch%
+set expectedExisting[0]=%branch%
+set expectedClose[0]=%branch%
 
 rem TODO: calculate from above
 set countNew=1


### PR DESCRIPTION
Test with branch as parameter. Default branch name is default
Bash with dash was working but there were no test for branch name with dash
It seems that bat was also working. Odd.